### PR TITLE
import_error_fix

### DIFF
--- a/Main Course.ipynb
+++ b/Main Course.ipynb
@@ -24,6 +24,7 @@
    "outputs": [],
    "source": [
     "!pip install stable-baselines3[extra]"
+    "!pip install gym[all]"
    ]
   },
   {


### PR DESCRIPTION
On step two there's a missing dependency, not sure what your preferred solution would be but wanted to raise it! -->

ImportError: 
    Cannot import pyglet.
    HINT: you can install pyglet directly via 'pip install pyglet'.
    But if you really just want to install all Gym dependencies and not have to think about it,
    'pip install -e .[all]' or 'pip install gym[all]' will do it.